### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,8 @@
 name: CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/p5quared/bazillionaire/security/code-scanning/4](https://github.com/p5quared/bazillionaire/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions` block to restrict the `GITHUB_TOKEN` to the least privileges required. For this workflow, the steps only need to read repository contents (for `actions/checkout`) and then use an external deployment token (`FLY_API_TOKEN`), so `contents: read` is sufficient.

The best minimal fix is:

- Add a `permissions` block at the workflow root (top level, alongside `name` and `on`) to apply to all jobs.
- Set `contents: read` there, as suggested by CodeQL.

Concretely, edit `.github/workflows/cd.yml`:

- After line 1 (`name: CD`) and the blank line, insert:

```yaml
permissions:
  contents: read
```

This does not change existing job behavior, because no step was relying on elevated write permissions from `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
